### PR TITLE
Loadout stats tweaks

### DIFF
--- a/content/data/scripts/shipselect.lua
+++ b/content/data/scripts/shipselect.lua
@@ -3,6 +3,7 @@ local class = require("class")
 local topics = require("ui_topics")
 local async_util = require("async_util")
 local loadoutHandler = require("loadouthandler")
+local utils = require("utils")
 
 --local AbstractBriefingController = require("briefingCommon")
 
@@ -471,13 +472,13 @@ function ShipSelectController:BuildInfo(entry)
 	
 	--Setup the hitpoints string
 	local hitpointsString = ''
-	for i = 1, math.floor(entry.Hitpoints / 50) do
+	for i = 1, utils.round(entry.Hitpoints / 50) do
 		hitpointsString = hitpointsString .. '++'
 	end
 	
 	--Setup the shield hitpoints string
 	local ShieldhitpointsString = ''
-	for i = 1, math.floor(entry.ShieldHitpoints / 50) do
+	for i = 1, utils.round(entry.ShieldHitpoints / 50) do
 		ShieldhitpointsString = ShieldhitpointsString .. '++'
 	end
 	

--- a/content/data/scripts/ui_topics.lua
+++ b/content/data/scripts/ui_topics.lua
@@ -1,11 +1,5 @@
 local Topic = require("Topic")
-
---round number function shared among all topics 
-function round(num, decimalPlaces)
-    local places = DecimalPlaces or 0
-    local multiplier = 10^places
-    return math.floor(num * multiplier + 0.5) / multiplier
-end
+local utils = require("utils") --to allow use of utils.round()
 
 local function altNameOrName(x)
 	local altName = x.AltName
@@ -41,7 +35,7 @@ local function weaponStats(weaponClass)
         else
         range = weaponClass.Range
     end
-	local rof = round(1 / weaponClass.FireWait, 2)
+	local rof = utils.round(1 / weaponClass.FireWait, 2)
     --[[ gross hacks begin here
     weapon = tb.WeaponClasses[weaponClass.Index]
     if weapon.SwarmInfo then
@@ -55,7 +49,7 @@ local function weaponStats(weaponClass)
     end
     local cscrewproxy = cscrewcount or 1 -- DANGEROUSLY CHEESY
     local burst = weaponClass.BurstShots
-    local volley = round(swarmproxy * cscrewproxy * burst)
+    local volley = utils.round(swarmproxy * cscrewproxy * burst)
     ba.warning("swarm count for " .. weaponClass.Name .. " is " .. swarmproxy)
      end gross hacks --]]
 	return {
@@ -65,8 +59,8 @@ local function weaponStats(weaponClass)
 		Velocity = velocity,
 		Range = range,
 		RoF = rof,
-		CargoSize = round(weaponClass.CargoSize, 2),
-		Power = round(weaponClass.EnergyConsumed / weaponClass.FireWait, 2),
+		CargoSize = utils.round(weaponClass.CargoSize, 2),
+		Power = utils.round(weaponClass.EnergyConsumed / weaponClass.FireWait, 2),
 		-- TODO: Use SwarmInfo and CorkscrewInfo to determine this automatically.
 		--VolleySize = tonumber(weaponClass.CustomData["volley"] or 1)
         VolleySize = 1

--- a/content/data/scripts/ui_topics.lua
+++ b/content/data/scripts/ui_topics.lua
@@ -23,10 +23,12 @@ local function weaponStats(weaponClass)
 	if weaponClass.OuterRadius > 0 then
 		-- This weapon has a shockwave, which gives it additional damage on a direct hit.
 		-- TODO: Most weapons have shockwave damage equal to their base damage, but not all.
-		local bonusDamage = baseDamage
+		local bonusDamage = weaponClass.ShockwaveDamage
 		baseDamage = baseDamage + bonusDamage
 	end
 	local velocity = weaponClass.Speed
+	local rof = utils.round(1 / weaponClass.FireWait, 2)
+
     -- account for +Weapon Range parameter -WW
     local range = weaponClass.Range or 999999
     local altrange = velocity * weaponClass.LifeMax
@@ -35,23 +37,23 @@ local function weaponStats(weaponClass)
         else
         range = weaponClass.Range
     end
-	local rof = utils.round(1 / weaponClass.FireWait, 2)
-    --[[ gross hacks begin here
-    weapon = tb.WeaponClasses[weaponClass.Index]
-    if weapon.SwarmInfo then
-        local isSwarmer, swarmcount, swarmwait = weapon.SwarmInfo
+
+    --[[ disabled until fix PR gets merged in FSO
+    if weaponClass.SwarmInfo then
+        local isSwarmer, swarmcount, swarmwait = weaponClass.SwarmInfo
         ba.warning("Swarm weapon " .. weaponClass.Name .. "detected with swarmcount" .. swarmcount)
     end
-    local swarmproxy = swarmcount or 1 -- there has got to be a better way to do this
-    if weapon.CorkscrewInfo then
-        local isCorkscrew, cscrewcount, cscrewwait, cscrewrotate, cscrewtwist = weapon.CorkscrewInfo
+    if weaponClass.CorkscrewInfo then
+        local isCorkscrew, cscrewcount, cscrewwait, cscrewrotate, cscrewtwist = weaponClass.CorkscrewInfo
         ba.warning("Corkscrew weapon " .. weaponClass.Name .. "detected with corkscrew " .. cscrewcount)
     end
-    local cscrewproxy = cscrewcount or 1 -- DANGEROUSLY CHEESY
+    --]]
+
+    local swarmproxy = swarmcount or 1 -- to prevent getting a nil value
+    local cscrewproxy = cscrewcount or 1
     local burst = weaponClass.BurstShots
     local volley = utils.round(swarmproxy * cscrewproxy * burst)
-    ba.warning("swarm count for " .. weaponClass.Name .. " is " .. swarmproxy)
-     end gross hacks --]]
+
 	return {
 		HullDamage = baseDamage * weaponClass.ArmorFactor,
 		ShieldDamage = baseDamage * weaponClass.ShieldFactor,
@@ -63,7 +65,7 @@ local function weaponStats(weaponClass)
 		Power = utils.round(weaponClass.EnergyConsumed / weaponClass.FireWait, 2),
 		-- TODO: Use SwarmInfo and CorkscrewInfo to determine this automatically.
 		--VolleySize = tonumber(weaponClass.CustomData["volley"] or 1)
-        VolleySize = 1
+        VolleySize = volley
 	}
 end
 

--- a/content/data/scripts/ui_topics.lua
+++ b/content/data/scripts/ui_topics.lua
@@ -23,41 +23,33 @@ local function weaponStats(weaponClass)
 	if weaponClass.OuterRadius > 0 then
 		-- This weapon has a shockwave, which gives it additional damage on a direct hit.
 		-- Added formula to calculate shockwave damage -- WW
-        if weaponClass.ShockwaveDamage and weaponClass.ShockwaveDamage > 0 then
-            bonusDamage = weaponClass.ShockwaveDamage
-        elseif weaponClass.ShockwaveDamage == 0 or weaponClass.ShockwaveDamage == nil then
-            bonusDamage = baseDamage
-        end
+		if weaponClass.ShockwaveDamage and weaponClass.ShockwaveDamage > 0 then
+			bonusDamage = weaponClass.ShockwaveDamage
+		elseif weaponClass.ShockwaveDamage == 0 or weaponClass.ShockwaveDamage == nil then
+			bonusDamage = baseDamage
+		end
 		baseDamage = baseDamage + bonusDamage
 	end
 
 	local velocity = weaponClass.Speed
 	local rof = utils.round(1 / weaponClass.FireWait, 2)
+	local range = math.min(weaponClass.Range, (velocity * weaponClass.LifeMax))
 
-    -- account for +Weapon Range parameter -WW
-    local range = weaponClass.Range or 999999
-    local altrange = velocity * weaponClass.LifeMax
-    if  range > altrange then
-        range = weaponClass.Speed * weaponClass.LifeMax
-        else
-        range = weaponClass.Range
-    end
+	--[[ disabled until fix PR gets merged in FSO
+	if weaponClass.SwarmInfo then
+		local isSwarmer, swarmcount, swarmwait = weaponClass.SwarmInfo
+		ba.warning("Swarm weapon " .. weaponClass.Name .. "detected with swarmcount" .. swarmcount)
+	end
+	if weaponClass.CorkscrewInfo then
+		local isCorkscrew, cscrewcount, cscrewwait, cscrewrotate, cscrewtwist = weaponClass.CorkscrewInfo
+		ba.warning("Corkscrew weapon " .. weaponClass.Name .. "detected with corkscrew " .. cscrewcount)
+	end
+	--]]
 
-    --[[ disabled until fix PR gets merged in FSO
-    if weaponClass.SwarmInfo then
-        local isSwarmer, swarmcount, swarmwait = weaponClass.SwarmInfo
-        ba.warning("Swarm weapon " .. weaponClass.Name .. "detected with swarmcount" .. swarmcount)
-    end
-    if weaponClass.CorkscrewInfo then
-        local isCorkscrew, cscrewcount, cscrewwait, cscrewrotate, cscrewtwist = weaponClass.CorkscrewInfo
-        ba.warning("Corkscrew weapon " .. weaponClass.Name .. "detected with corkscrew " .. cscrewcount)
-    end
-    --]]
-
-    local swarmproxy = swarmcount or 1 -- to prevent getting a nil value
-    local cscrewproxy = cscrewcount or 1
-    local burst = weaponClass.BurstShots
-    local volley = utils.round(swarmproxy * cscrewproxy * burst)
+	local swarmproxy = swarmcount or 1 -- to prevent getting a nil value
+	local cscrewproxy = cscrewcount or 1
+	local burst = weaponClass.BurstShots
+	local volley = utils.round(swarmproxy * cscrewproxy * burst)
 
 	return {
 		HullDamage = baseDamage * weaponClass.ArmorFactor,
@@ -70,7 +62,7 @@ local function weaponStats(weaponClass)
 		Power = utils.round(weaponClass.EnergyConsumed / weaponClass.FireWait, 2),
 		-- TODO: Use SwarmInfo and CorkscrewInfo to determine this automatically.
 		--VolleySize = tonumber(weaponClass.CustomData["volley"] or 1)
-        VolleySize = volley
+		VolleySize = volley
 	}
 end
 

--- a/content/data/scripts/ui_topics.lua
+++ b/content/data/scripts/ui_topics.lua
@@ -25,8 +25,8 @@ local function weaponStats(weaponClass)
 		-- Added formula to calculate shockwave damage -- WW
 		if weaponClass.ShockwaveDamage and weaponClass.ShockwaveDamage > 0 then
 			bonusDamage = weaponClass.ShockwaveDamage
-			else
-			ba.print("Shockwave damage is identical to base weapon damage. Assuming shockwave is not specified and skipping shockwave formula.\n")
+		else
+			ba.print("Shockwave damage returned zero. Assuming equal to base damage.\n")
 			bonusDamage = baseDamage
 		end
 		baseDamage = baseDamage + bonusDamage

--- a/content/data/scripts/ui_topics.lua
+++ b/content/data/scripts/ui_topics.lua
@@ -22,10 +22,15 @@ local function weaponStats(weaponClass)
 	local baseDamage = weaponClass.Damage
 	if weaponClass.OuterRadius > 0 then
 		-- This weapon has a shockwave, which gives it additional damage on a direct hit.
-		-- TODO: Most weapons have shockwave damage equal to their base damage, but not all.
-		local bonusDamage = weaponClass.ShockwaveDamage
+		-- Added formula to calculate shockwave damage -- WW
+        if weaponClass.ShockwaveDamage and weaponClass.ShockwaveDamage > 0 then
+            bonusDamage = weaponClass.ShockwaveDamage
+        elseif weaponClass.ShockwaveDamage == 0 or weaponClass.ShockwaveDamage == nil then
+            bonusDamage = baseDamage
+        end
 		baseDamage = baseDamage + bonusDamage
 	end
+
 	local velocity = weaponClass.Speed
 	local rof = utils.round(1 / weaponClass.FireWait, 2)
 

--- a/content/data/scripts/ui_topics.lua
+++ b/content/data/scripts/ui_topics.lua
@@ -25,7 +25,7 @@ local function weaponStats(weaponClass)
 		-- Added formula to calculate shockwave damage -- WW
 		if weaponClass.ShockwaveDamage and weaponClass.ShockwaveDamage > 0 then
 			bonusDamage = weaponClass.ShockwaveDamage
-		elseif weaponClass.ShockwaveDamage == 0 or weaponClass.ShockwaveDamage == nil then
+			else
 			bonusDamage = baseDamage
 		end
 		baseDamage = baseDamage + bonusDamage
@@ -36,21 +36,19 @@ local function weaponStats(weaponClass)
 	local range = math.min(weaponClass.Range, (velocity * weaponClass.LifeMax))
 
 	-- new code to calculate volley size -- WW
-	local isSwarmer, swarmcount, swarmwait = weaponClass:getSwarmInfo()
-	local isCorkscrew, cscrewcount, cscrewwait, cscrewrotate, cscrewtwist = weaponClass:getCorkscrewInfo()
-	local swarmproxy = math.max(swarmcount, 1) --swarmcount returns -1 if invalid
+	local isSwarmer, SwarmCount = weaponClass:getSwarmInfo()
+	local isCorkscrew, CorkscrewCount = weaponClass:getCorkscrewInfo()
 
-	local cscrewproxy = 1
-	if isCorkscrew then
-		cscrewproxy = cscrewcount
+	if not isSwarmer then
+		SwarmCount = 1
 	end
 
-	local burst = 1
-	if weaponClass.BurstShots > 1 then
-		burst = weaponClass.BurstShots
+	if not isCorkscrew then
+		CorkscrewCount = 1
 	end
 
-	local volley = utils.round(swarmproxy * cscrewproxy * burst)
+	local burst = math.max(weaponClass.BurstShots, 1)
+	local volley = utils.round(SwarmCount * CorkscrewCount * burst)
 	-- end volley code
 
 	return {

--- a/content/data/scripts/ui_topics.lua
+++ b/content/data/scripts/ui_topics.lua
@@ -26,6 +26,7 @@ local function weaponStats(weaponClass)
 		if weaponClass.ShockwaveDamage and weaponClass.ShockwaveDamage > 0 then
 			bonusDamage = weaponClass.ShockwaveDamage
 			else
+			ba.print("Shockwave damage is identical to base weapon damage. Assuming shockwave is not specified and skipping shockwave formula.\n")
 			bonusDamage = baseDamage
 		end
 		baseDamage = baseDamage + bonusDamage

--- a/content/data/scripts/ui_topics.lua
+++ b/content/data/scripts/ui_topics.lua
@@ -35,21 +35,23 @@ local function weaponStats(weaponClass)
 	local rof = utils.round(1 / weaponClass.FireWait, 2)
 	local range = math.min(weaponClass.Range, (velocity * weaponClass.LifeMax))
 
-	--[[ disabled until fix PR gets merged in FSO
-	if weaponClass.SwarmInfo then
-		local isSwarmer, swarmcount, swarmwait = weaponClass.SwarmInfo
-		ba.warning("Swarm weapon " .. weaponClass.Name .. "detected with swarmcount" .. swarmcount)
-	end
-	if weaponClass.CorkscrewInfo then
-		local isCorkscrew, cscrewcount, cscrewwait, cscrewrotate, cscrewtwist = weaponClass.CorkscrewInfo
-		ba.warning("Corkscrew weapon " .. weaponClass.Name .. "detected with corkscrew " .. cscrewcount)
-	end
-	--]]
+	-- new code to calculate volley size -- WW
+	local isSwarmer, swarmcount, swarmwait = weaponClass:getSwarmInfo()
+	local isCorkscrew, cscrewcount, cscrewwait, cscrewrotate, cscrewtwist = weaponClass:getCorkscrewInfo()
+	local swarmproxy = math.max(swarmcount, 1) --swarmcount returns -1 if invalid
 
-	local swarmproxy = swarmcount or 1 -- to prevent getting a nil value
-	local cscrewproxy = cscrewcount or 1
-	local burst = weaponClass.BurstShots
+	local cscrewproxy = 1
+	if isCorkscrew then
+		cscrewproxy = cscrewcount
+	end
+
+	local burst = 1
+	if weaponClass.BurstShots > 1 then
+		burst = weaponClass.BurstShots
+	end
+
 	local volley = utils.round(swarmproxy * cscrewproxy * burst)
+	-- end volley code
 
 	return {
 		HullDamage = baseDamage * weaponClass.ArmorFactor,
@@ -60,8 +62,6 @@ local function weaponStats(weaponClass)
 		RoF = rof,
 		CargoSize = utils.round(weaponClass.CargoSize, 2),
 		Power = utils.round(weaponClass.EnergyConsumed / weaponClass.FireWait, 2),
-		-- TODO: Use SwarmInfo and CorkscrewInfo to determine this automatically.
-		--VolleySize = tonumber(weaponClass.CustomData["volley"] or 1)
 		VolleySize = volley
 	}
 end

--- a/content/data/scripts/utils.lua
+++ b/content/data/scripts/utils.lua
@@ -2,6 +2,14 @@ local utils = {}
 
 utils.table = {}
 
+
+--round number function shared among all topics 
+function utils.round(num, decimalPlaces)
+    local places = DecimalPlaces or 0
+    local multiplier = 10^places
+    return math.floor(num * multiplier + 0.5) / multiplier
+end
+
 --Parses an XSTR from Custom data if it's formated like so:
 -- +Val: NAME "string", #
 --and returns the string and id in a table

--- a/content/data/scripts/utils.lua
+++ b/content/data/scripts/utils.lua
@@ -5,7 +5,7 @@ utils.table = {}
 
 --round number function shared among all topics 
 function utils.round(num, decimalPlaces)
-    local places = DecimalPlaces or 0
+    local places = decimalPlaces or 0
     local multiplier = 10^places
     return math.floor(num * multiplier + 0.5) / multiplier
 end

--- a/content/data/scripts/weaponselect.lua
+++ b/content/data/scripts/weaponselect.lua
@@ -753,11 +753,11 @@ function WeaponSelectController:BuildInfo(entry)
 	
 	ScpuiSystem:ClearEntries(infoEl)
 	
-	local power = utils.round(entry.Power)
+	local power = entry.Power
 	local rof = entry.RoF
 	local velocity = utils.round(entry.Velocity)
-	local range = utils.round(1 * entry.Range)
-	local cargoSize = entry.CargoSize
+	local range = utils.round(entry.Range)
+	local cargoSize = utils.round(entry.CargoSize, 2)
 	
 	local desc_el = self.document:CreateElement("p")
 	desc_el.inner_rml = entry.Description

--- a/content/data/scripts/weaponselect.lua
+++ b/content/data/scripts/weaponselect.lua
@@ -3,6 +3,7 @@ local class = require("class")
 local async_util = require("async_util")
 local loadoutHandler = require("loadouthandler")
 local topics = require("ui_topics")
+local utils = require("utils")
 
 local WeaponSelectController = class()
 
@@ -754,10 +755,10 @@ function WeaponSelectController:BuildInfo(entry)
 	
     local weapon = tb.WeaponClasses[entry.Index]
     ba.warning("Weapon reported as " .. weapon.Name)
-	local power = round(entry.Power)
+	local power = utils.round(entry.Power)
 	local rof = entry.RoF
-	local velocity = round(entry.Velocity)
-	local range = round(1 * entry.Range)
+	local velocity = utils.round(entry.Velocity)
+	local range = utils.round(1 * entry.Range)
 	local cargoSize = entry.CargoSize
 	
 	local desc_el = self.document:CreateElement("p")
@@ -776,15 +777,15 @@ function WeaponSelectController:BuildInfo(entry)
     end
 	local volley = entry.VolleySize or 1
 	if entry.Type == "secondary" and entry.FireWait >= 1 then
-		local hull = round(entry.HullDamage * volley)
-		local shield = round(entry.ShieldDamage * volley)
-		local subsystem = round(entry.SubsystemDamage * volley)
+		local hull = utils.round(entry.HullDamage * volley)
+		local shield = utils.round(entry.ShieldDamage * volley)
+		local subsystem = utils.round(entry.SubsystemDamage * volley)
 		local label = (volley == 1) and ba.XSTR("Damage per missile", 888432) or ba.XSTR("Damage per volley", 888433)
 		stats2_el.inner_rml = label .. ": " .. hull .. " " .. ba.XSTR("Hull", 888434) .. ", " .. shield .. " " .. ba.XSTR("Shield", 888435) .. ", " .. subsystem .. " " .. ba.XSTR("Subsystem", 888436)
 	else
-		local hull = round(entry.HullDamage * volley / entry.FireWait)
-		local shield = round(entry.ShieldDamage * volley / entry.FireWait)
-		local subsystem = round(entry.SubsystemDamage * volley / entry.FireWait)
+		local hull = utils.round(entry.HullDamage * volley / entry.FireWait)
+		local shield = utils.round(entry.ShieldDamage * volley / entry.FireWait)
+		local subsystem = utils.round(entry.SubsystemDamage * volley / entry.FireWait)
 		stats2_el.inner_rml = ba.XSTR("Damage per second", 888437) .. ": " .. hull .. " " .. ba.XSTR("Hull", 888434) .. ", " .. shield .. " " .. ba.XSTR("Shield", 888435) .. ", " .. subsystem .. " " .. ba.XSTR("Subsystem", 888436)
 	end
 	stats2_el:SetClass("red", true)

--- a/content/data/scripts/weaponselect.lua
+++ b/content/data/scripts/weaponselect.lua
@@ -753,8 +753,6 @@ function WeaponSelectController:BuildInfo(entry)
 	
 	ScpuiSystem:ClearEntries(infoEl)
 	
-    local weapon = tb.WeaponClasses[entry.Index]
-    ba.warning("Weapon reported as " .. weapon.Name)
 	local power = utils.round(entry.Power)
 	local rof = entry.RoF
 	local velocity = utils.round(entry.Velocity)
@@ -771,11 +769,9 @@ function WeaponSelectController:BuildInfo(entry)
 	
 	local stats2_el = self.document:CreateElement("p")
 	stats2_el:SetClass("info", true)
-    if weapon.SwarmInfo then
-        local isSwarmer, swarmcount, swarmwait = weapon.SwarmInfo
-        ba.warning("Swarm weapon " .. weapon.Name .. "detected with swarmcount" .. swarmcount)
-    end
+
 	local volley = entry.VolleySize or 1
+
 	if entry.Type == "secondary" and entry.FireWait >= 1 then
 		local hull = utils.round(entry.HullDamage * volley)
 		local shield = utils.round(entry.ShieldDamage * volley)

--- a/content/data/scripts/weaponselect.lua
+++ b/content/data/scripts/weaponselect.lua
@@ -752,10 +752,12 @@ function WeaponSelectController:BuildInfo(entry)
 	
 	ScpuiSystem:ClearEntries(infoEl)
 	
-	local power = math.floor(entry.Power)
+    local weapon = tb.WeaponClasses[entry.Index]
+    ba.warning("Weapon reported as " .. weapon.Name)
+	local power = round(entry.Power)
 	local rof = entry.RoF
-	local velocity = math.floor(entry.Velocity)
-	local range = math.floor(entry.Range)
+	local velocity = round(entry.Velocity)
+	local range = round(1 * entry.Range)
 	local cargoSize = entry.CargoSize
 	
 	local desc_el = self.document:CreateElement("p")
@@ -768,17 +770,21 @@ function WeaponSelectController:BuildInfo(entry)
 	
 	local stats2_el = self.document:CreateElement("p")
 	stats2_el:SetClass("info", true)
+    if weapon.SwarmInfo then
+        local isSwarmer, swarmcount, swarmwait = weapon.SwarmInfo
+        ba.warning("Swarm weapon " .. weapon.Name .. "detected with swarmcount" .. swarmcount)
+    end
 	local volley = entry.VolleySize or 1
 	if entry.Type == "secondary" and entry.FireWait >= 1 then
-		local hull = math.floor(entry.HullDamage * volley)
-		local shield = math.floor(entry.ShieldDamage * volley)
-		local subsystem = math.floor(entry.SubsystemDamage * volley)
+		local hull = round(entry.HullDamage * volley)
+		local shield = round(entry.ShieldDamage * volley)
+		local subsystem = round(entry.SubsystemDamage * volley)
 		local label = (volley == 1) and ba.XSTR("Damage per missile", 888432) or ba.XSTR("Damage per volley", 888433)
 		stats2_el.inner_rml = label .. ": " .. hull .. " " .. ba.XSTR("Hull", 888434) .. ", " .. shield .. " " .. ba.XSTR("Shield", 888435) .. ", " .. subsystem .. " " .. ba.XSTR("Subsystem", 888436)
 	else
-		local hull = math.floor(entry.HullDamage * volley / entry.FireWait)
-		local shield = math.floor(entry.ShieldDamage * volley / entry.FireWait)
-		local subsystem = math.floor(entry.SubsystemDamage * volley / entry.FireWait)
+		local hull = round(entry.HullDamage * volley / entry.FireWait)
+		local shield = round(entry.ShieldDamage * volley / entry.FireWait)
+		local subsystem = round(entry.SubsystemDamage * volley / entry.FireWait)
 		stats2_el.inner_rml = ba.XSTR("Damage per second", 888437) .. ": " .. hull .. " " .. ba.XSTR("Hull", 888434) .. ", " .. shield .. " " .. ba.XSTR("Shield", 888435) .. ", " .. subsystem .. " " .. ba.XSTR("Subsystem", 888436)
 	end
 	stats2_el:SetClass("red", true)


### PR DESCRIPTION
### Loading Stats Tweaks and Fixes
A set of changes to `ui_topics.lua`, `weaponselect.lua`, and `utils.lua` to enhance the functionality of the weapon select screen.

### Changes:

* New `utils.round(float number, int precision)` function rounds a floating point number to a specified number of decimal places. Useful for preventing incorrect readings (like "4.99/s" for the Subach fire rate) due to floating point precision limitations, or cutting down repeating decimals.
* Range accounts for `+Weapon Range:` in weapons.tbl.
* Shockwave damage is correctly accounted for when computing damage.
* Corrected energy consumption formula that closely matches that of the old mediavps.
* Weapon damage now accounts for swarm, corkscrew, and burst count.