### PR TITLE
Small whitespace and Font Count/Number cleanup

### DIFF
--- a/content/data/scripts/dialogs.lua
+++ b/content/data/scripts/dialogs.lua
@@ -42,23 +42,25 @@ end
 local function initialize_buttons(document, properties, finish_func)
     for i, v in ipairs(properties.buttons) do
         local button_id = 'button_' .. tostring(i)
-            local button = document:GetElementById(button_id)
+        local button = document:GetElementById(button_id)
         button:SetClass(module.BUTTON_MAPPING[v.type], true)
         button:SetClass("button_1", true)
         button:SetClass("button_img", true)
+
         button:AddEventListener("click", function(_, _, _)
-        local val = v.value
-        if properties.input_choice then
-            val = document:GetElementById("dialog_input"):GetAttribute("value")
-        end
-        if finish_func then finish_func(val) end
-        --document:Close()
-		ScpuiSystem:CloseDialog()
-    end)
+            local val = v.value
+            if properties.input_choice then
+                val = document:GetElementById("dialog_input"):GetAttribute("value")
+            end
+            if finish_func then finish_func(val) end
+            --document:Close()
+            ScpuiSystem:CloseDialog()
+        end)
+
         local button_text_id = button_id .. '_text'
-            local button_text = document:GetElementById(button_text_id)
-            button_text.inner_rml = text_with_keypress(v.text, v.keypress)
-            button_text:SetClass(module.BUTTON_TEXT_MAPPING[v.type], true)
+        local button_text = document:GetElementById(button_text_id)
+        button_text.inner_rml = text_with_keypress(v.text, v.keypress)
+        button_text:SetClass(module.BUTTON_TEXT_MAPPING[v.type], true)
     end
 end
 

--- a/content/data/tables/a_ui_functions-sct.tbm
+++ b/content/data/tables/a_ui_functions-sct.tbm
@@ -103,9 +103,9 @@ function ScpuiSystem:getFontPixelSize(val)
 	
 	function convert(value)
 		if not value then return nil end
-	    local clamped_value = math.max(0, math.min(1, value))
+		local clamped_value = math.max(0, math.min(1, value))
 	    local scaled_value = (clamped_value - 0.5) * 20
-	    return math.floor(scaled_value + 0.5)
+		return math.floor(scaled_value + 0.5)
 	end
 	
 	if not val then
@@ -114,7 +114,7 @@ function ScpuiSystem:getFontPixelSize(val)
 		val = convert(val)
 	end
 	
-	local finalSize = math.max(1, math.min(40, pixelSize + val))
+	local finalSize = math.max(1, math.min(ScpuiSystem.numFontSizes, pixelSize + val))
 	
 	return tostring(finalSize)
 end


### PR DESCRIPTION
Mainly make the `40` in `ScpuiSystem:getFontPixelSize` not a magic number. Also cleaned up a bit of whitespace where it made reading a tad trickier