### PR TITLE
Fix two more barracks issues

### DIFF
--- a/content/data/interface/markup/barracks.rml
+++ b/content/data/interface/markup/barracks.rml
@@ -175,7 +175,7 @@
 			</div>
 			<div id=pilot_squad_select>
 				<div id=pilot_squad_images>
-					<img id="pilot_squad_img_el" src="lion1.pcx"></img>
+					<img id="pilot_squad_img_el" src=""></img>
 				</div>
 				<div id=pilot_squad_counter>
 					<p id="pilot_squad_text_el">1 of N</p>

--- a/content/data/scripts/barracks.lua
+++ b/content/data/scripts/barracks.lua
@@ -338,9 +338,11 @@ end
 function BarracksScreenController:global_keydown(element, event)
 	if self.mode == PilotSelectController.MODE_BARRACKS then
 		if event.parameters.key_identifier == rocket.key_identifier.ESCAPE then
-			if self.selectedPilot ~= nil then
-				ui.Barracks.acceptPilot(self.selectedPilot, false)
+			if self.selectedPilot == nil then
+                ui.playElementSound(element, "click", "error")
+                return
 			end
+            ui.Barracks.acceptPilot(self.selectedPilot, false)
 			event:StopPropagation()
 			ba.postGameEvent(ba.GameEvents["GS_EVENT_MAIN_MENU"])
 		end


### PR DESCRIPTION
Found two more small issues with Barracks. One is that SCPUI allows the player to press escape and exit to mainhall when all players are deleted, though I have fixed this with just an early return.

The other one is that SCPUI does not need to specify a default multiplayer logo since that will throw errors for mods in which it does not exist. Removing the default in the RML has no effect sine the lua file builds the lists dynamically anyway.

Tested and both work as expected.