### PR TITLE
Have Font Resolution Multiplier be a variable instead of hard coded

### DIFF
--- a/content/data/tables/a_ui_functions-sct.tbm
+++ b/content/data/tables/a_ui_functions-sct.tbm
@@ -97,7 +97,7 @@ end
 
 function ScpuiSystem:getFontPixelSize(val)
 	local vmin = math.min(gr.getScreenWidth(), gr.getScreenHeight())
-	local size = vmin * 0.012 --Gets rougly 12px font on 1080p
+	local size = vmin * ScpuiSystem.font_resolution_multiplier
 	-- Lua has no math.round(); math.floor(x + 0.5) is the idiomatic replacement.
 	local pixelSize = math.floor(size + 0.5)
 	

--- a/content/data/tables/ui_system-sct.lua
+++ b/content/data/tables/ui_system-sct.lua
@@ -12,6 +12,7 @@ local renderCategory = engine.createTracingCategory("RenderRocket", true)
 
 ScpuiSystem = {
 	active = true,
+	font_resolution_multiplier = 0.012, --Gets roughly 12px font on 1080p
 	numFontSizes = 40,
 	replacements = {},
 	backgrounds = {},


### PR DESCRIPTION
Totally understand if this is decided to be not incorporated, but just wanted to raise the point now that I have chatted with a few more FotG folks. 

Currently our base font size, and thus what the players see as their first impression, is at size 16 for 1080. I know the 0.012 value was based on standard practice for font resolution methods used, though I just wanted to check if you might be open to just moving the 0.012 to a variable here, that way mods can set the base font resolution multiplier exactly to the kinds of fonts they might be using. 

Again, happy to withdraw PR if this is something you don't want in the main repo!