### PR TITLE
Dialog order consistency

### DIFF
--- a/content/data/scripts/ctrlr_options.lua
+++ b/content/data/scripts/ctrlr_options.lua
@@ -238,8 +238,8 @@ function OptionsController:acceptChanges(state)
     builder:title(ba.XSTR("Restart required", 888385))
     builder:text(dialog_text)
 	builder:escape(false)
-    builder:button(Dialogs.BUTTON_TYPE_NEGATIVE, ba.XSTR("Cancel", 888091), false, string.sub(ba.XSTR("Cancel", 888091), 1, 1))
     builder:button(Dialogs.BUTTON_TYPE_POSITIVE, ba.XSTR("Ok", 888286), true, string.sub(ba.XSTR("Ok", 888286), 1, 1))
+    builder:button(Dialogs.BUTTON_TYPE_NEGATIVE, ba.XSTR("Cancel", 888091), false, string.sub(ba.XSTR("Cancel", 888091), 1, 1))
     builder:show(self.Document.context):continueWith(function(val)
         if val then
 
@@ -1530,8 +1530,8 @@ end
 function OptionsController:exit_game_clicked(element)
     local builder = Dialogs.new()
     builder:text(ba.XSTR("Exit Game?", 888390))
-    builder:button(Dialogs.BUTTON_TYPE_NEGATIVE, ba.XSTR("No", 888298), false)
     builder:button(Dialogs.BUTTON_TYPE_POSITIVE, ba.XSTR("Yes", 888296), true)
+    builder:button(Dialogs.BUTTON_TYPE_NEGATIVE, ba.XSTR("No", 888298), false)
     builder:show(self.Document.context):continueWith(function(result)
         if not result then
             return

--- a/content/data/scripts/ctrlr_pilot_select.lua
+++ b/content/data/scripts/ctrlr_pilot_select.lua
@@ -424,8 +424,8 @@ function PilotSelectController:actualPilotCreate(element, callsign, clone_from)
         builder:title(ba.XSTR("Warning", 888284))
         builder:text(ba.XSTR("A duplicate pilot exists\nOverwrite?", 888401))
         builder:escape(false)
-        builder:button(Dialogs.BUTTON_TYPE_NEGATIVE, ba.XSTR("No", 888298), false, "n")
         builder:button(Dialogs.BUTTON_TYPE_POSITIVE, ba.XSTR("Yes", 888296), true, "y")
+        builder:button(Dialogs.BUTTON_TYPE_NEGATIVE, ba.XSTR("No", 888298), false, "n")
         builder:show(self.Document.context):continueWith(function(result)
             if not result then
                 return
@@ -498,8 +498,8 @@ function PilotSelectController:delete_player(element)
     builder:title(ba.XSTR("Warning!", 888395))
     builder:text(ba.XSTR("Are you sure you wish to delete this pilot?", 888407))
     builder:escape(false)
-    builder:button(Dialogs.BUTTON_TYPE_NEGATIVE, "No", false, "n")
     builder:button(Dialogs.BUTTON_TYPE_POSITIVE, "Yes", true, "y")
+    builder:button(Dialogs.BUTTON_TYPE_NEGATIVE, "No", false, "n")
     builder:show(self.Document.context):continueWith(function(result)
         if not result then
             return


### PR DESCRIPTION
Make all dialogs consistently show `cancel/no` as top choice then `yes/confirm` as bottom choice. Most SCPUI already have this pattern but I found 4 that do not. (a bit backwards since to have the order in the dialog be No, Yes the order in the code needs to be Yes, No.