### PR TITLE
Update scpui_sm_parser.lua

### DIFF
--- a/content/data/scripts/scpui_sm_parser.lua
+++ b/content/data/scripts/scpui_sm_parser.lua
@@ -249,6 +249,19 @@ function ScpuiSystem:parseScpuiTable(data)
 
 			ScpuiSystem.data.Backgrounds_List_Campaign[campaign] = classname
 		end
+		
+				
+		while parse.optionalString("$Mainhall Background:") do
+				parse.requiredString("+Mainhall Name:")
+				local mainhall = Utils.strip_extension(parse.getString())
+
+				parse.requiredString("+RCSS Class Name:")
+				local classname = parse.getString()
+
+				ScpuiSystem.data.Backgrounds_List_Mainhall[mainhall] = classname
+			end
+
+	end
 
 	end
 


### PR DESCRIPTION
For reasons I don't understand, I was getting an error trying to get mainhall backgrounds to work.

I also don't know what the difference is between the sequence that starts at line 215 or the sequence that starts at line 241, or why the 215 sequence has $mainhall background in there somehwere, whilst the 241 sequence does not.

What I do understand is that copying the mainhall background loader section from the 215 sequence to the 241 sequence makes the mainhall background feature work.

For the record, this was the table that was causing FSO to throw an error:
```#Settings
$Mod ID: BluePlanetComplete
$Default FSO Font Name: SCPUI
$Database Unread Show String Badge: False
$Database Unread Show Icon Badge: False
$Database Unread Item Class: unreadentry
$Minimum Splash Time: 0
$Draw Splash Images: False
$Draw Splash Text: False

#Background Replacement
$Campaign Background:
+Campaign Filename: FSBlue
+RCSS Class Name: fs2bg

$Campaign Background:
+Campaign Filename: bp
+RCSS Class Name: BP1-Mainhall1
$Campaign Background:
+Campaign Filename: bp2-p1
+RCSS Class Name: BP2-Mainhall1
$Campaign Background:
+Campaign Filename: bp2-p2
+RCSS Class Name: BP2-Mainhall3
$Campaign Background:
+Campaign Filename: bp2-p3
+RCSS Class Name: BP2-Mainhall4

$Mainhall Background:
+Mainhall Name: BP1-Start
+RCSS Class Name: BP1-Mainhall1

$Mainhall Background:
+Mainhall Name: BP1-Middle
+RCSS Class Name: BP1-Mainhall2

$Mainhall Background:
+Mainhall Name: BP1-End
+RCSS Class Name: BP1-Mainhall3

$Mainhall Background:
+Mainhall Name: BP2-Act1
+RCSS Class Name: BP2-Mainhall1

$Mainhall Background:
+Mainhall Name: BP2-Act2
+RCSS Class Name: BP2-Mainhall2

$Mainhall Background:
+Mainhall Name: BP2-Act3
+RCSS Class Name: BP2-Mainhall3

$Mainhall Background:
+Mainhall Name: BP2-Act4
+RCSS Class Name: BP2-Mainhall4

$Mainhall Background:
+Mainhall Name: BP2-Act5
+RCSS Class Name: BP2-Mainhall5

$Mainhall Background:
+Mainhall Name: BP2-TBI
+RCSS Class Name: BP2-MainhallTBI
#End```

It loads correctly with this PR.