### PR TITLE
Fix Standalone Check

### DIFF
--- a/content/data/scripts/scpui_system_core.lua
+++ b/content/data/scripts/scpui_system_core.lua
@@ -93,7 +93,7 @@ ScpuiSystem.data = {
 ScpuiSystem.extensions = {}
 
 --keep multiplayer standalone servers lean
-if ba.getCurrentMPStatus() == "MULTIPLAYER_STANDALONE" then
+if ba.inStandalone() then
 	ScpuiSystem.data.Active = nil
 	return
 end


### PR DESCRIPTION
With 25.0.1-RC1 out (or just on current master) the SCPUI code that checks for standalone status should be updated. Previously it was ba.getCurrentMPStatus() == "MULTIPLAYER_STANDALONE", which turns out does not work on game init, but the new value ba.inStandalone() does work and should be used in it's place